### PR TITLE
Fix: Footer shows correct HostsUp count (alive hosts instead of total targets)

### DIFF
--- a/powermap.ps1
+++ b/powermap.ps1
@@ -615,5 +615,5 @@ $totalScanned = $expandedTargets.Count
 $actualHostsUp = $aliveHosts.Count
 
 
-Write-NmapFooter -TotalScanned $totalScanned -HostsUp $expandedTargets.Count -Duration $duration
+Write-NmapFooter -TotalScanned $totalScanned -HostsUp $actualHostsUp -Duration $duration
 


### PR DESCRIPTION
Fixes #2

This PR addresses the bug where the footer incorrectly displays the total number of targets as 'HostsUp' instead of the actual count of alive hosts.

## Changes
- Modified Write-NmapFooter call to use $actualHostsUp (which contains $aliveHosts.Count) instead of $expandedTargets.Count

## Testing
The fix ensures that when scanning multiple targets where some are down, the footer will correctly report only the number of hosts that responded as alive, not the total number of targets scanned.

Before: PowerMap done: 10 IP addresses (10 hosts up) scanned in X seconds (even if only 3 were actually up)
After: PowerMap done: 10 IP addresses (3 hosts up) scanned in X seconds (correctly shows 3 alive hosts)